### PR TITLE
Миграция на node16

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
         ovm_version: ['1.2.1', latest]
     name: check oscript
     steps:
-    - uses: actions/checkout@v2 
+    - uses: actions/checkout@v4
     - uses: ./
       with:
         version: ${{ matrix.oscript_version }}

--- a/action.yml
+++ b/action.yml
@@ -13,5 +13,5 @@ inputs:
     required: false
     default: 'latest'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
See https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/