### PR TITLE
Исправление определения пути к OneScript в режиме debug

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28414,17 +28414,18 @@ async function run() {
         await execCommand('ovm', ['install', osVersion]);
         await execCommand('ovm', ['use', osVersion]);
 
-        let output = '';
+        let pathOscript = '';
         const options = {};
         options.listeners = {
             stdout: (data) => {
-                if (data.toString().includes('ovm')) {
-                    output += data.toString();
+                let output = data.toString().trim();
+                let fileName = path.parse(output).name;
+                if (fileName == 'oscript' && fs.existsSync(output)) {
+                    pathOscript = path.dirname(output);
                 }
             }
         };
         await execCommand('ovm', ['which', 'current'], options);
-        let pathOscript = path.dirname(output);
 
         core.addPath(pathOscript);
 

--- a/src/index.js
+++ b/src/index.js
@@ -66,17 +66,18 @@ async function run() {
         await execCommand('ovm', ['install', osVersion]);
         await execCommand('ovm', ['use', osVersion]);
 
-        let output = '';
+        let pathOscript = '';
         const options = {};
         options.listeners = {
             stdout: (data) => {
-                if (data.toString().includes('ovm')) {
-                    output += data.toString();
+                let output = data.toString().trim();
+                let fileName = path.parse(output).name;
+                if (fileName == 'oscript' && fs.existsSync(output)) {
+                    pathOscript = path.dirname(output);
                 }
             }
         };
         await execCommand('ovm', ['which', 'current'], options);
-        let pathOscript = path.dirname(output);
 
         core.addPath(pathOscript);
 


### PR DESCRIPTION
Данный ПР исправляет определение пути к OneScript в режиме debug. В переменную среды `OSCRIPTBIN` ранее устанавливался ненужный текст логов из потока вывода команды `ovm which current`.

Тесты в режиме debug: https://github.com/Stivo182/setup-onescript/actions/runs/14694858967
Тесты в обычном режиме: https://github.com/Stivo182/setup-onescript/actions/runs/14694835163