### PR TITLE
fix: Установка mono на macOS по необходимости

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false
       matrix:
         oscript_version: [lts, stable, dev]
-        os: [macOS-latest, ubuntu-latest, windows-latest]
-        ovm_version: ['1.2.1', latest]
+        os: [macOS-latest, macos-14, ubuntu-latest, windows-latest]
+        ovm_version: [latest]
     name: check oscript
     steps:
     - uses: actions/checkout@v4

--- a/dist/index.js
+++ b/dist/index.js
@@ -28467,6 +28467,7 @@ function installLinux() {
 function installMacOs() {
     var value = [];
     value.push('#!/bin/bash');
+    value.push('command -v mono >/dev/null 2>&1 || brew install mono');
     value.push('mv ovm.exe /usr/local/bin/');
     let cmd = 'mono /usr/local/bin/ovm.exe "$@"';
     value.push("echo '" + cmd + "' | tee /usr/local/bin/ovm");

--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,7 @@ function installLinux() {
 function installMacOs() {
     var value = [];
     value.push('#!/bin/bash');
+    value.push('command -v mono >/dev/null 2>&1 || brew install mono');
     value.push('mv ovm.exe /usr/local/bin/');
     let cmd = 'mono /usr/local/bin/ovm.exe "$@"';
     value.push("echo '" + cmd + "' | tee /usr/local/bin/ovm");


### PR DESCRIPTION
- На macos-latest теперь отсутствует предустановленная mono. Добавил проверку наличия mono и установку при отсутствии. https://github.com/actions/runner-images/issues/12520
- Добавил тест на macos-14 (с установленной mono).
- Удалил тест на ovm 1.2.1.